### PR TITLE
Update SyncOrder.php

### DIFF
--- a/Cron/SyncOrder.php
+++ b/Cron/SyncOrder.php
@@ -30,11 +30,14 @@ class SyncOrder
 
     public function execute()
     {
+        $rmaAllowedOrderStatuses = $this->scopeConfig->getValue('reversio_rma/mapping/rma_allowed_order_statuses');
+        
         $orderCollection = $this->orderCollectionFactory->create()
             ->addFieldToFilter('reversio_sync_status', ['in' => [
                 \ReversIo\RMA\Helper\Constants::REVERSIO_SYNC_STATUS_SYNC_ERROR,
                 \ReversIo\RMA\Helper\Constants::REVERSIO_SYNC_STATUS_NOT_SYNC
             ]])
+            ->addFieldToFilter('state', ['in' => explode(',', $rmaAllowedOrderStatuses)])
             ->setPageSize($this->batchSize);
 
         $syncOrderStartDate = $this->scopeConfig->getValue('reversio_rma/mapping/sync_order_start_date');


### PR DESCRIPTION
We should filter orders to sync using allowed return states. 

Because in my case with a website with many existing orders, this script will treat 25 orders by 25 orders. If the new 25 orders  are not allowed to be sync, the system is stuck. 

e.g

In my case the next 25 orders got the state "cancelled" so on each cron run, it get 25 orders cancelled not to sync, so it will never sync `completed` orders